### PR TITLE
Adds repository mirroring for wpcomvip/vip-governance-plugin

### DIFF
--- a/.github/workflows/mirror-wpcomvip.yml
+++ b/.github/workflows/mirror-wpcomvip.yml
@@ -4,11 +4,11 @@ on: [push, delete]
 
 jobs:
   to_wpcomvip:
-    # Only run this job on the root repository
-    env:
-      IS_ROOT_REPOSITORY: ${{ secrets.WPCOMVIP_GOVERNANCE_DEPLOY_KEY != '' }}
-    if: env.IS_ROOT_REPOSITORY == 'true'
     runs-on: ubuntu-latest
+
+    # Only run this job on the root repository
+    if: github.repository == 'Automattic/vip-governance-plugin'
+
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description

Use [repository-mirroring-action](https://github.com/marketplace/actions/mirroring-repository) to automatically sync git changes. Some notes about how this works:

1. The mirroring action [is very simple](https://github.com/pixta-dev/repository-mirroring-action/blob/main/mirror.sh) and uses a simple `git` command to sync all branches, commits, and tags across the repository. This means in-progress branches be synced, which may not be ideal, but is minor. If we want to limit the branches we sync to only `trunk`/`media`, we could fork the action without a ton of effort.

2. No GitHub-specific repository metadata is synced. Pull requests and issues will be left private in Automattic. Although release tags will be synced, the actual release content and ZIP will not be. After creating a release tag, we'll need to create a release in both repositories manually.

3. A secret has been set up in this repository.

## Steps to Test

Because of how GitHub actions work and the triggers set up (`on: [push, delete]`), this action is already running successfully
