### PR TITLE
Remove the beta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,29 @@ This plugin is currently developed for use on WordPress sites hosted on the VIP 
 
 ## Installation
 
-The latest version of the VIP Governance plugin is available in the default `trunk` branch of this repository.
+### Install on WordPress VIP
+
+The VIP Governance plugin is authored and maintained by [WordPress VIP][wpvip], and made available to all WordPress sites by [VIP MU plugins][vip-go-mu-plugins]. Customers who host on WordPress VIP or use [`vip dev-env`](https://docs.wpvip.com/how-tos/local-development/use-the-vip-local-development-environment/) to develop locally have access to this plugin automatically. We recommend this activation method for WordPress VIP customers.
+
+Enable the plugin by adding the method shown below to your application's [`client-mu-plugins/plugin-loader.php`][vip-go-skeleton-plugin-loader-example]:
+
+```php
+// client-mu-plugins/plugin-loader.php
+
+\Automattic\VIP\Integrations\activate( 'vip-governance' );
+```
+
+Create this path in your WordPress VIP site if it does not yet exist.
+
+This will automatically install and activate the latest mu-plugins release of the VIP Governance plugin. Remove this line to deactivate the plugin.
+
+To use the VIP Governance plugin after activation, skip to [Usage](#usage).
 
 ### Install via `git subtree`
+
+We recommend this method for non-[WordPress VIP][wpvip] customers.
+
+The latest version of the VIP Governance plugin is available in the default `trunk` branch of this repository.
 
 We recommend installing the latest plugin version [via `git subtree`][wpvip-plugin-subtrees] within your site's repository:
 
@@ -49,7 +69,7 @@ We recommend installing the latest plugin version [via `git subtree`][wpvip-plug
 cd my-site-repo/
 
 # Add a subtree for the trunk branch:
-git subtree add --prefix plugins/vip-governance git@github.com:wpcomvip/vip-governance-plugin.git trunk --squash
+git subtree add --prefix plugins/vip-governance git@github.com:Automattic/vip-governance-plugin.git trunk --squash
 ```
 
 To deploy the plugin to a remote branch, `git push` the committed subtree.
@@ -57,7 +77,7 @@ To deploy the plugin to a remote branch, `git push` the committed subtree.
 The `trunk` branch will stay up to date with the latest version of the plugin. Use this command to pull the latest `trunk` branch changes:
 
 ```bash
-git subtree pull --prefix plugins/vip-governance git@github.com:wpcomvip/vip-governance-plugin.git trunk --squash
+git subtree pull --prefix plugins/vip-governance git@github.com:Automattic/vip-governance-plugin.git trunk --squash
 ```
 
 Ensure that the plugin is up-to-date by pulling changes often.
@@ -67,16 +87,6 @@ Note: We **do not recommend** using `git submodule`. [Submodules on WPVIP that r
 ### Install via ZIP file
 
 The latest version of the plugin can be downloaded from the [repository's Releases page][repo-releases]. Unzip the downloaded plugin and add it to the `plugins/` directory of your site's GitHub repository.
-
-### Plugin activation
-
-Usually, VIP recommends [activating plugins with code][wpvip-plugin-activate]. In this case, we are recommending activating the plugin in the WordPress Admin dashboard. This will allow the plugin to be more easily enabled and disabled during testing.
-
-To activate the installed plugin:
-
-1. Navigate to the WordPress Admin dashboard as a logged-in user.
-2. Select **Plugins** from the lefthand navigation menu.
-3. Locate the "VIP Governance" plugin in the list and select the "Activate" link located below it.
 
 ## Usage
 
@@ -597,14 +607,13 @@ npx playwright test
 
 <!-- Links -->
 
-[settings-panel-example-gif]: https://github.com/wpcomvip/vip-governance-plugin/blob/media/vip-governance-admin-settings-animation.gif
+[settings-panel-example-gif]: https://github.com/automattic/vip-governance-plugin/blob/media/vip-governance-admin-settings-animation.gif
 [analytics-file]: governance/analytics.php
 [repo-governance-file-location]: governance-rules.json
 [repo-schema-location]: governance-schema.json
 [gutenberg-block-settings]: https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#settings
 [repo-analytics]: governance/analytics.php
-[repo-issue-create]: https://github.com/wpcomvip/vip-governance-plugin/issues/new/choose
-[repo-releases]: https://github.com/wpcomvip/vip-governance-plugin/releases
+[repo-releases]: https://github.com/automattic/vip-governance-plugin/releases
 [vip-go-mu-plugins]: https://github.com/Automattic/vip-go-mu-plugins/
 [wp-custom-roles]: https://developer.wordpress.org/reference/functions/add_role/
 [wp-default-roles]: https://wordpress.org/documentation/article/roles-and-capabilities/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This WordPress plugin adds additional governance capabilities to the block edito
 
 We have approached this plugin from an opt-in standpoint. In other words, enabling this plugin without any rules will severely limit the editing experience. The goal is to create a stable editor with new blocks and features being enabled explicitly via rules, rather than implicitly via updates.
 
+This plugin is currently developed for use on WordPress sites hosted on the VIP Platform.
+
 ## Table of contents
 
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
----
-### :warning: This plugin is currently in Beta. It is designed to run on [WordPress VIP][wpvip]. This beta release is not intended for use on a production environment.
----
-
 # VIP Governance plugin
 
 This WordPress plugin adds additional governance capabilities to the block editor. This is accomplished via two dimensions:
@@ -86,7 +82,7 @@ Your governance rules are saved in `governance-rules.json`. Before diving into h
 
 ### Schema Basics
 
-You can find the schema definition used for the rules [here][repo-schema-location]. Including a schema entry in your rules will provide for code completion in most editors.
+You can find the schema definition used for the rules [here][repo-schema-location]. You can use `https://api.wpvip.com/schemas/plugins/governance.json` as the schema entry in your rules, to take advantage of code completion in most editors.
 
 We have allowed significant space for customization. This means it is also possible to create unintended rule interactions. We recommend making rule changes one or two at a time to troubleshoot these interactions.
 
@@ -94,10 +90,10 @@ Each rule is an object in an array. The one required property is `type`, which c
 
 Rules not of type `default` require an additional field. These are broken down below, along with examples of their possible values:
 
-| Rule Type     | Required Field| Possible Values     |
-| ------------- | ------------- | -------------       |
-| `role`  | `roles`  | name/slug of any [default][wp-default-roles] or [custom][wp-custom-roles] roles        |
-| `postType`  | `postTypes`  | name/slug of any [default][wp-default-post-types] or [custom][wp-custom-post-types] post types        |
+| Rule Type  | Required Field | Possible Values                                                                                |
+|------------|----------------|------------------------------------------------------------------------------------------------|
+| `role`     | `roles`        | name/slug of any [default][wp-default-roles] or [custom][wp-custom-roles] roles                |
+| `postType` | `postTypes`    | name/slug of any [default][wp-default-post-types] or [custom][wp-custom-post-types] post types |
 
 Each rule can have any one of the following properties.
 
@@ -114,7 +110,7 @@ So if a matching `postType` and `role` rule is found, the `role` rule will be ap
 
 ### Quick Start
 
-By default, the plugin uses [this](repo-governance-file-location) `governance-rules.json`. We recommend duplicating this file into your [private folder][wpvip-private-dir], and adapting it for your needs. In order to use the rules schema for in-editor support, duplicate the `governance-schema.json` into your private folder as well.
+By default, the plugin uses [this][repo-governance-file-location] `governance-rules.json`. We recommend duplicating one of the starter rule sets provided [below](#starter-rule-sets), and adapting it for your needs. In order to take advantage of the rules schema for in-editor support, use `https://api.wpvip.com/schemas/plugins/governance.json`.
 
 With this default rule set, all blocks and all features are enabled. It is sensible to set your default rule to the settings you want for your least privileged user then add capabilities with role and/or post type-specific rules.
 
@@ -128,7 +124,7 @@ This is the default rule set used by the plugin.
 
 ```json
 {
-  "$schema": "./governance-schema.json",
+  "$schema": "https://api.wpvip.com/schemas/plugins/governance.json",
   "version": "1.0.0",
   "rules": [
     {
@@ -153,7 +149,7 @@ This expands the default rule set by adding restrictions for all users and post 
 
 ```json
 {
-  "$schema": "./governance-schema.json",
+  "$schema": "https://api.wpvip.com/schemas/plugins/governance.json",
   "version": "1.0.0",
   "rules": [
     {
@@ -241,7 +237,7 @@ This example focuses on providing a restrictive default rule set, and expanded p
 
 ```json
 {
-  "$schema": "./governance-schema.json",
+  "$schema": "https://api.wpvip.com/schemas/plugins/governance.json",
   "version": "1.0.0",
   "rules": [
     {
@@ -323,7 +319,7 @@ This example focuses on providing a restrictive default rule set, and expanded p
 
 ```json
 {
-  "$schema": "./governance-schema.json",
+  "$schema": "https://api.wpvip.com/schemas/plugins/governance.json",
   "version": "1.0.0",
   "rules": [
     {
@@ -525,7 +521,7 @@ It has only three root level keys: `allowedBlocks`, `blockSettings`, and `allowe
 
 #### Example
 
-This example involves making a call to `http://my.site/wp-json/vip-governance/v1/editor/rules` for an `editor` role, while using [this]((#default-and-user-role-rule-set)) rule file found in the starter rule sets:
+This example involves making a call to `http://my.site/wp-json/vip-governance/v1/editor/rules` for an `editor` role, while using [this](#default-and-user-role-rule-set) rule file found in the starter rule sets:
 
 ```json
 {

--- a/governance-rules.json
+++ b/governance-rules.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "./governance-schema.json",
+	"$schema": "https://api.wpvip.com/schemas/plugins/governance.json",
 	"version": "1.0.0",
 	"rules": [
 		{

--- a/governance/analytics.php
+++ b/governance/analytics.php
@@ -87,8 +87,7 @@ class Analytics {
 	private static function is_wpvip_site() {
 		return defined( 'WPCOM_IS_VIP_ENV' ) && constant( 'WPCOM_IS_VIP_ENV' ) === true
 			&& defined( 'WPCOM_SANDBOXED' ) && constant( 'WPCOM_SANDBOXED' ) === false
-			&& defined( 'FILES_CLIENT_SITE_ID' )
-				&& function_exists( '\Automattic\VIP\Stats\send_pixel' );
+			&& defined( 'FILES_CLIENT_SITE_ID' ) && function_exists( '\Automattic\VIP\Stats\send_pixel' );
 	}
 }
 

--- a/governance/analytics.php
+++ b/governance/analytics.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Analytics for Block Governance.
- * 
+ *
  * @package vip-governance
  */
 
@@ -15,14 +15,14 @@ defined( 'ABSPATH' ) || die();
 class Analytics {
 	/**
 	 * Array of analytics to send to the WP Pixel.
-	 * 
+	 *
 	 * @var array
 	 */
 	private static $analytics_to_send = [];
 
 	/**
 	 * Initialize the Analytics class.
-	 * 
+	 *
 	 * @access private
 	 */
 	public static function init() {
@@ -31,7 +31,7 @@ class Analytics {
 
 	/**
 	 * Record the usage of the plugin, for VIP sites only. For non-VIP sites, this is a no-op.
-	 * 
+	 *
 	 * @return void
 	 */
 	public static function record_usage() {
@@ -56,8 +56,8 @@ class Analytics {
 	}
 
 	/**
-	 * Send the analytics, if present. If an error is present, then usage analytics are not sent. 
-	 * 
+	 * Send the analytics, if present. If an error is present, then usage analytics are not sent.
+	 *
 	 * @return void
 	 */
 	public static function send_analytics() {
@@ -73,45 +73,22 @@ class Analytics {
 			unset( self::$analytics_to_send[ WPCOMVIP__GOVERNANCE__STAT_NAME___USAGE ] );
 		}
 
-		self::send_pixel( self::$analytics_to_send );
-	}
-
-	/**
-	 * Send the stats to the WP Pixel.
-	 *
-	 * @param array $stats Stats to be sent.
-	 * @return void
-	 */
-	private static function send_pixel( $stats ) {
-		$query_args = [
-			'v' => 'wpcom-no-pv',
-		];
-
-		foreach ( $stats as $name => $group ) {
-			$query_param = rawurlencode( 'x_' . $name );
-			$query_value = rawurlencode( $group );
-
-			$query_args[ $query_param ] = $query_value;
+		// Use the built-in mu-plugins methods to send the data to VIP Stats.
+		if ( function_exists( '\Automattic\VIP\Stats\send_pixel' ) ) {
+			\Automattic\VIP\Stats\send_pixel( self::$analytics_to_send );
 		}
-
-		$pixel = add_query_arg( $query_args, 'http://pixel.wp.com/b.gif' );
-
-		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
-		wp_remote_get( $pixel, array(
-			'blocking' => false,
-			'timeout'  => 1,
-		) );
 	}
 
 	/**
 	 * Check if the site is a WPVIP site.
-	 * 
+	 *
 	 * @return bool true If it is a WPVIP site, false otherwise
 	 */
 	private static function is_wpvip_site() {
 		return defined( 'WPCOM_IS_VIP_ENV' ) && constant( 'WPCOM_IS_VIP_ENV' ) === true
 			&& defined( 'WPCOM_SANDBOXED' ) && constant( 'WPCOM_SANDBOXED' ) === false
-			&& defined( 'FILES_CLIENT_SITE_ID' );
+			&& defined( 'FILES_CLIENT_SITE_ID' )
+				&& function_exists( '\Automattic\VIP\Stats\send_pixel' );
 	}
 }
 

--- a/tests/private/governance-rules.json
+++ b/tests/private/governance-rules.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "../../governance-schema.json",
+	"$schema": "https://api.wpvip.com/schemas/plugins/governance.json",
 	"version": "1.0.0",
 	"rules": [
 		{

--- a/vip-governance.php
+++ b/vip-governance.php
@@ -17,8 +17,8 @@
 
 namespace WPCOMVIP\Governance;
 
-if ( ! defined( 'VIP_BLOCK_GOVERNANCE_LOADED' ) ) {
-	define( 'VIP_BLOCK_GOVERNANCE_LOADED', true );
+if ( ! defined( 'VIP_GOVERNANCE_LOADED' ) ) {
+	define( 'VIP_GOVERNANCE_LOADED', true );
 
 	define( 'WPCOMVIP__GOVERNANCE__PLUGIN_VERSION', '1.0.0' );
 	define( 'WPCOMVIP__GOVERNANCE__RULES_SCHEMA_VERSION', '1.0.0' );


### PR DESCRIPTION
## Description

- Remove the beta tag from the repo
- Add the new schema URL in the README examples as well as in the rules files we use for our plugin and the tests.
- Switch the analytics pixel code for the mu-plugins method
- Update the README.md to catch items that were missed in the last PR. I have noted in the examples the new schema url, and encouraged that to be used.

