### PR TITLE
Fix the private path directory not being valid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "block-editor-governance",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "block-editor-governance",
-			"version": "1.0.3",
+			"version": "1.0.4",
 			"devDependencies": {
 				"@automattic/eslint-plugin-wpvip": "0.6.0",
 				"@playwright/test": "^1.36.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "block-editor-governance",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "This is a plugin adding additional governance capabilities to the block editor.",
 	"author": "VIP Bistro",
 	"main": "build/index.js",

--- a/vip-governance.php
+++ b/vip-governance.php
@@ -5,7 +5,7 @@
  * Description: Add additional governance capabilities to the block editor.
  * Author: WordPress VIP
  * Text Domain: vip-governance
- * Version: 1.0.3
+ * Version: 1.0.4
  * Requires at least: 5.9.0
  * Tested up to: 6.3.0
  * Requires PHP: 7.4
@@ -20,7 +20,7 @@ namespace WPCOMVIP\Governance;
 if ( ! defined( 'VIP_GOVERNANCE_LOADED' ) ) {
 	define( 'VIP_GOVERNANCE_LOADED', true );
 
-	define( 'WPCOMVIP__GOVERNANCE__PLUGIN_VERSION', '1.0.3' );
+	define( 'WPCOMVIP__GOVERNANCE__PLUGIN_VERSION', '1.0.4' );
 	define( 'WPCOMVIP__GOVERNANCE__RULES_SCHEMA_VERSION', '1.0.0' );
 
 	if ( ! defined( 'WPCOMVIP_GOVERNANCE_ROOT_PLUGIN_FILE' ) ) {


### PR DESCRIPTION
## Description

This is a hotfix as storing the rules in the private directory would break with the latest filter. This was due to the fact that the private directory was not under wp-content. Now, we take the path from the env variable itself to ensure this does not repeat itself.

## Steps to Test

Repeat the tests from https://github.com/Automattic/vip-governance-plugin/pull/60
Also, load this on a VIP site and store the rules under a private directory

