### PR TITLE
enqueue scripts and styles using url

### DIFF
--- a/governance/init-governance.php
+++ b/governance/init-governance.php
@@ -57,7 +57,7 @@ class InitGovernance {
 
 		wp_enqueue_script(
 			'wpcomvip-governance',
-			WPCOMVIP_GOVERNANCE_ROOT_PLUGIN_DIR . '/build/index.js',
+			plugins_url( '/build/index.js', WPCOMVIP_GOVERNANCE_ROOT_PLUGIN_FILE ),
 			$asset_file['dependencies'],
 			$asset_file['version'],
 			true /* in_footer */
@@ -91,7 +91,7 @@ class InitGovernance {
 
 		wp_enqueue_style(
 			'wpcomvip-governance',
-			WPCOMVIP_GOVERNANCE_ROOT_PLUGIN_DIR . '/css/vip-governance.css',
+			plugins_url( '/css/vip-governance.css', WPCOMVIP_GOVERNANCE_ROOT_PLUGIN_FILE ),
 			/* dependencies */ [],
 			WPCOMVIP__GOVERNANCE__PLUGIN_VERSION
 		);

--- a/governance/settings/settings.php
+++ b/governance/settings/settings.php
@@ -71,7 +71,7 @@ class Settings {
 	public static function enqueue_resources() {
 		wp_enqueue_style(
 			'wpcomvip-governance-settings',
-			WPCOMVIP_GOVERNANCE_ROOT_PLUGIN_DIR . '/governance/settings/settings.css',
+			plugins_url( '/governance/settings/settings.css', WPCOMVIP_GOVERNANCE_ROOT_PLUGIN_FILE ),
 			/* dependencies */ [],
 			WPCOMVIP__GOVERNANCE__PLUGIN_VERSION
 		);
@@ -87,7 +87,7 @@ class Settings {
 	public static function enqueue_scripts() {
 		wp_enqueue_script(
 			'wpcomvip-governance-settings',
-			WPCOMVIP_GOVERNANCE_ROOT_PLUGIN_DIR . '/governance/settings/settings.js',
+			plugins_url( '/governance/settings/settings.js', WPCOMVIP_GOVERNANCE_ROOT_PLUGIN_FILE ),
 			/* dependencies */ [ 'wp-api' ],
 			WPCOMVIP__GOVERNANCE__PLUGIN_VERSION,
 			/* in footer */ true


### PR DESCRIPTION
Fixes #66 

- Text the plugin on a URL where the internal path isn't the same as the public path (e.g. `/var/www/html`)
- Settings page should work
- Editor should be governed
- There should be no 404s for plugin assets