### PR TITLE
Add analytics sampling

### DIFF
--- a/governance/init-governance.php
+++ b/governance/init-governance.php
@@ -120,7 +120,13 @@ class InitGovernance {
 				$block_settings_for_user   = $governance_rules_for_user['blockSettings'];
 				$nested_settings_and_css   = NestedGovernanceProcessing::get_nested_settings_and_css( $block_settings_for_user );
 				BlockLocking::init( $governance_rules_for_user['allowedFeatures'] );
-				Analytics::record_usage();
+
+				$epoch_time = floor( microtime( true ) );
+
+				if ( ( $epoch_time % 10 ) === 0 ) {
+					// Sample results. Only send analytics on 10% of configuration loads.
+					Analytics::record_usage();
+				}
 			}
 		} catch ( Exception | Error $e ) {
 			// This is an unexpected exception. Record error for follow-up with WPVIP customers.


### PR DESCRIPTION
## Description

See https://github.com/Automattic/vip-governance-plugin/issues/96. Load analytics are recorded for VIP sites on each governance configuration load, which happens when the WordPress editor is opened. This amount of data isn't necessary and can have a small effect on editor load time.

This PR adds time-based sampling to usage analytics to reduce the number of analytics calls by 90%.

## Steps to Test

1. Debug the plugin in a local environment. Use either a breakpoint or logging in the `Analytics::record_usage()` call to determine when analytics would normally fire.
2. Open any existing post in the admin interface, or a new post through Admin → Posts → Add New Post.
3. Refresh the page a few times. Analytics should only fire 10% of requests, when `( $epoch_time % 10 ) === 0`.

