### PR TITLE
Update actions upload-artifact to v4

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: npx playwright test
 
       - name: Upload playwright artifacts on failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: playwright-artifacts

--- a/tests/e2e/default-administrator-rule-check.spec.js
+++ b/tests/e2e/default-administrator-rule-check.spec.js
@@ -57,6 +57,7 @@ test.describe( 'Role/Post Type - Default, Administrator and Post Rules Flow', ()
 			'Heading',
 			'Image',
 			'Media & Text',
+			"Something that doesn't belong",
 		] );
 	} );
 
@@ -181,7 +182,7 @@ test.describe( 'Role/Post Type - Default, Administrator and Post Rules Flow', ()
 		// Verify if the CSS was actually applied.
 		const frame = page.frame( 'editor-canvas' );
 		const rootHeading = frame.locator( 'text="This is a heading"' );
-		await expect( rootHeading ).toHaveCSS( 'color', 'rgb(255, 255, 0)' );
+		await expect( rootHeading ).toHaveCSS( 'color', 'rgb(255, 255, 100)' );
 
 		const nestedHeading = frame.locator( 'text="This is a heading inside a media-text"' );
 		await expect( nestedHeading ).toHaveCSS( 'color', 'rgb(255, 0, 0)' );

--- a/tests/e2e/default-administrator-rule-check.spec.js
+++ b/tests/e2e/default-administrator-rule-check.spec.js
@@ -57,7 +57,6 @@ test.describe( 'Role/Post Type - Default, Administrator and Post Rules Flow', ()
 			'Heading',
 			'Image',
 			'Media & Text',
-			"Something that doesn't belong",
 		] );
 	} );
 
@@ -182,7 +181,7 @@ test.describe( 'Role/Post Type - Default, Administrator and Post Rules Flow', ()
 		// Verify if the CSS was actually applied.
 		const frame = page.frame( 'editor-canvas' );
 		const rootHeading = frame.locator( 'text="This is a heading"' );
-		await expect( rootHeading ).toHaveCSS( 'color', 'rgb(255, 255, 100)' );
+		await expect( rootHeading ).toHaveCSS( 'color', 'rgb(255, 255, 0)' );
 
 		const nestedHeading = frame.locator( 'text="This is a heading inside a media-text"' );
 		await expect( nestedHeading ).toHaveCSS( 'color', 'rgb(255, 0, 0)' );


### PR DESCRIPTION
## Description

From [`@actions/upload-artifact`](https://github.com/actions/upload-artifact):

> [!WARNING]
> actions/upload-artifact@v3 is scheduled for deprecation on **November 30, 2024**. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
> Similarly, v1/v2 are scheduled for deprecation on **June 30, 2024**.
> Please update your workflow to use v4 of the artifact actions.
> This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.

None of the breaking changes seem to apply to our usage, so we can safely update directly to `v4`.
