### PR TITLE
Update Blueprint's PHP version to 8.1

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -2,7 +2,7 @@
   "$schema": "https://playground.wordpress.net/blueprint-schema.json",
   "landingPage": "/wp-admin/admin.php?page=vip-block-governance",
   "preferredVersions": {
-    "php": "8.0",
+    "php": "8.1",
     "wp": "latest"
   },
   "features": {


### PR DESCRIPTION
The plugin defines that it requires PHP 8.1, but the playground blueprint is set to 8.0, so it fails to run when using this blueprint. 

See required PHP version: https://github.com/Automattic/vip-governance-plugin/blob/trunk/vip-governance.php#L11

This PR bumps the PHP version in blueprint.json to match the plugin's required version.

## Description
The Playground link in the readme currently does not work, as the plugin requires PHP 8.1, but the blueprint specifies 8.0.

## Steps to Test

1. Open the existing blueprint, it will fail as the plugin cannot be activated: https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/vip-governance-plugin/trunk/blueprint.json

2. Open the updated blueprint, ensure it starts the playground correctly: https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/vip-governance-plugin/9c56b4dfb54ba626c796fe4c8a511c79a71cdb29/blueprint.json
