### PR TITLE
Plugin Maintenance - docs and release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,22 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: 'weekly'
+      day: 'monday'
     open-pull-requests-limit: 10
     groups:
       actions-minor-patch:
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "minor"
-          - "patch"
+          - 'minor'
+          - 'patch'
       actions-major:
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "major"
+          - 'major'
     cooldown:
       default-days: 7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,6 @@ npx wp-env start     # Starts the local WordPress environments
 ```bash
 npm run build        # Production build (webpack)
 npm run dev          # Watch mode for development
-npm run release -- patch --dry-run # Test a patch release without Git commands
 ```
 
 ### Linting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ npx wp-env start     # Starts the local WordPress environments
 ```bash
 npm run build        # Production build (webpack)
 npm run dev          # Watch mode for development
-npm run release -- patch --dry-run # Preview a patch release
+npm run release -- patch --dry-run # Test a patch release without Git commands
 ```
 
 ### Linting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ governance/
   governance-utilities.php      # Core rule parsing and filtering logic
   init-governance.php           # Plugin initialization, asset loading
   nested-governance-processing.php  # Nested block settings and CSS generation
-  rules-parser.php              # JSON validation against schema
+  rules-parser.php              # JSON parsing and runtime rule-logic validation
   rest/
-    rest-api.php                # REST endpoint: vip-governance/v1/<role>/rules
+    rest-api.php                # REST endpoint: vip-governance/v1/rules
   settings/
     settings.php                # Admin settings page registration
     settings-view.php           # Settings page HTML template
@@ -46,6 +46,7 @@ src/
   block-utils.js                # Block name matching, hierarchy validation
   block-locking.jsx             # React UI for block locking
   nested-governance-loader.js   # Loads nested governance settings
+bin/release                     # Creates and commits major/minor/patch release branches
 build/                          # Compiled JS output (do not edit directly)
 tests/
   test-governance-utilities.php # PHPUnit tests for rule logic
@@ -96,7 +97,7 @@ The plugin exposes `VIP_GOVERNANCE` to the block editor with:
 1. Post Type rules
 2. Role rules (highest priority — overrides post type rules)
 
-Non-default rules merge with the default rule. Schema: `https://api.wpvip.com/schemas/plugins/governance.json`
+Only the first matching rule of each type is used. A role rule replaces fields it defines from a matching post-type rule; omitted fields retain the post-type value. The default rule is then added to the selected non-default values. Schema: `https://api.wpvip.com/schemas/plugins/governance.json`
 
 ### Wildcard Limitation
 
@@ -125,8 +126,9 @@ Non-default rules merge with the default rule. Schema: `https://api.wpvip.com/sc
 ### Setup
 
 ```bash
-npm install          # Installs both npm and composer dependencies
-wp-env start         # Starts local WordPress environment at localhost:8889
+npm ci               # Installs JavaScript and production Composer dependencies
+composer install     # Adds PHP development tools
+npx wp-env start     # Starts the local WordPress environments
 ```
 
 ### Building
@@ -134,6 +136,7 @@ wp-env start         # Starts local WordPress environment at localhost:8889
 ```bash
 npm run build        # Production build (webpack)
 npm run dev          # Watch mode for development
+npm run release -- patch --dry-run # Preview a patch release
 ```
 
 ### Linting
@@ -187,7 +190,7 @@ npm run test         # Runs both PHP and JS unit tests
 - **PHP versions**: 8.1, 8.3
 - **WordPress versions**: 6.0, latest
 - **Checks on PR**: JS lint, JS unit tests, PHPCS, PHPUnit (3 matrix combos)
-- **Release on trunk push**: Auto-creates GitHub release with ZIP
+- **Release on trunk push**: Auto-creates a GitHub release and ZIP when the plugin header version changes
 
 ## Writing Tests
 
@@ -274,9 +277,9 @@ test.describe( 'My Feature', () => {
 
 1. **Admin settings page**: Navigate to `VIP Block Governance` in the WordPress admin. It shows:
    - Whether the plugin is active
-   - All parsed rules, with any schema validation errors highlighted
+   - All parsed rules, with JSON and rule-logic errors highlighted
    - Combined rules preview for a specific role and/or post type
-2. **REST API**: `GET /wp-json/vip-governance/v1/<role>/rules` — returns the merged rules for a given role (requires `manage_options` capability)
+2. **REST API**: `GET /wp-json/vip-governance/v1/rules?role=<role>&postType=<post-type>` — returns merged rules for an optional role and/or post type (requires `manage_options` capability)
 3. **Browser devtools**: Inspect the `VIP_GOVERNANCE` global in the console. It contains:
    - `governanceRules` — the resolved rules for the current user
    - `nestedSettings` — pre-computed nested block settings
@@ -289,12 +292,13 @@ test.describe( 'My Feature', () => {
 - **JS not updating?** Run `npm run build` or `npm run dev` (watch mode). Check that `build/index.js` was regenerated.
 - **PHP changes not reflecting?** Ensure `wp-env` is running. No build step needed for PHP.
 - **Test failures in CI?** Check the CI matrix — tests run against PHP 8.1/8.3 and WP 6.0/latest. Failures may be version-specific.
+- **Unexpected vendor changes?** Composer regenerates tracked metadata under `vendor/composer`. Only commit those changes when intentionally updating the production dependency bundle.
 
 ## REST API
 
-### `GET vip-governance/v1/<role>/rules`
+### `GET vip-governance/v1/rules?role=<role>&postType=<post-type>`
 
-Returns merged governance rules for a given role. Requires `manage_options` capability.
+Returns merged governance rules for an optional role and/or post type. Requires `manage_options` capability.
 
 **Response shape:**
 
@@ -308,8 +312,8 @@ Returns merged governance rules for a given role. Requires `manage_options` capa
 
 ## Important Notes
 
-- The plugin takes an **opt-in approach**: enabling it without rules severely limits the editor. Only explicitly allowed blocks/features are available.
+- The plugin takes an **opt-in approach**: an empty effective rule set severely limits the editor. The bundled fallback rule explicitly allows all blocks and supported features.
 - Always include `core/paragraph` in `allowedBlocks` for default rules — the editor uses it as an insertion primitive.
 - The plugin only works in the **post editor** (not site-editor, widgets, etc.).
 - Starting from WordPress 6.8, the block inserter sidebar shows all blocks regardless; disallowed blocks show a snackbar error on insertion attempt.
-- Analytics are VIP-only and contain no content/metadata — just counters with site ID.
+- Analytics are VIP-only and contain no content/metadata — just counters with site ID. Usage is sampled on roughly 10% of configuration loads.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Read `AGENTS.md` in this repository for a comprehensive overview of the project 
 
 ## Commands
 
+- `npm ci && composer install` — Install JavaScript and PHP development dependencies
 - `npm run build` — Production build
 - `npm run dev` — Watch mode
 - `npm run lint` — All linting (Prettier + ESLint + PHPCS)
@@ -29,10 +30,10 @@ Read `AGENTS.md` in this repository for a comprehensive overview of the project 
 
 ## Debugging
 
-- Local dev at `http://localhost:8889` (admin/password)
+- Main local site at `http://localhost:8888`; tests site at `http://localhost:8889` (`admin`/`password`)
 - Inspect `VIP_GOVERNANCE` global in browser devtools for resolved rules
 - Admin settings page (`VIP Block Governance`) shows parsed rules and validation errors
-- REST API: `GET /wp-json/vip-governance/v1/<role>/rules`
+- REST API: `GET /wp-json/vip-governance/v1/rules?role=<role>&postType=<post-type>`
 - See AGENTS.md "Debugging" section for common debugging steps
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # WordPress VIP Block Governance plugin
 
-This WordPress plugin adds additional governance capabilities to the block editor. This is accomplished via two dimensions:
+This WordPress plugin adds additional governance capabilities to the block editor. This is accomplished via three dimensions:
 
 - Insertion: restricts what kind of blocks can be inserted into the block editor. Only what’s allowed can be inserted, and nothing else. This means that even if new core blocks are introduced they would not be permitted.
 - Interaction: This adds the ability to control the styling available for blocks at any level.
+- Features: controls access to the code editor and block locking.
 
-We have approached this plugin from an opt-in standpoint. In other words, enabling this plugin without any rules will severely limit the editing experience. The goal is to create a stable editor with new blocks and features being enabled explicitly via rules, rather than implicitly via updates.
+We have approached this plugin from an opt-in standpoint. An empty effective rule set severely limits the editing experience, although the plugin ships with a permissive fallback rule set. The goal is to create a stable editor with new blocks and features being enabled explicitly via rules, rather than implicitly via updates.
 
 This plugin is currently developed for use on WordPress sites hosted on the VIP Platform.
 
@@ -33,7 +34,7 @@ This plugin is currently developed for use on WordPress sites hosted on the VIP 
 	- [`vip_governance__default_role_for_user_without_roles`](#vip_governance__default_role_for_user_without_roles)
 - [Admin Settings](#admin-settings)
 - [Endpoints](#endpoints)
-	- [`vip-governance/v1/<role>/rules`](#vip-governancev1rolerules)
+	- [`vip-governance/v1/rules`](#vip-governancev1rules)
 		- [Example](#example)
 - [Analytics](#analytics)
 - [Development](#development)
@@ -59,17 +60,17 @@ The latest version of the plugin can be downloaded from the [repository's Releas
 
 ## Usage
 
-Your governance rules are saved in `governance-rules.json` in [your private folder][wpvip-private-dir]. Before diving into how it's used, a quick run down of the schema will shed light on how it works.
+On WordPress VIP, place your governance rules in `governance-rules.json` in [your private folder][wpvip-private-dir]. When that file does not exist, the plugin uses the permissive [`governance-rules.json` bundled with the plugin][repo-governance-file-location]. The source can also be changed with the filters described below.
 
 Note: The [private folder][wpvip-private-dir] is only supported on VIP sites, or while using [`vip dev-env`](https://docs.wpvip.com/how-tos/local-development/use-the-vip-local-development-environment/) locally.
 
 ### Schema Basics
 
-You can find the schema definition used for the rules [here][repo-schema-location]. You can use `https://api.wpvip.com/schemas/plugins/governance.json` as the schema entry in your rules, to take advantage of code completion in most editors.
+You can find the JSON Schema for authoring rules [here][repo-schema-location]. Use `https://api.wpvip.com/schemas/plugins/governance.json` as the `$schema` value to get code completion and validation in supported editors. At runtime, the plugin parses JSON and applies its own required rule-logic checks rather than evaluating this schema file directly.
 
 We have allowed significant space for customization. This means it is also possible to create unintended rule interactions. We recommend making rule changes one or two at a time to troubleshoot these interactions.
 
-Each rule is an object in an array. The one required property is `type`, which can be `default`, `role`, or `postType`. Your rules should only have one entry of the `default` type, as described below, and it is the only type that is required in your rule set.
+Each rule is an object in an array. The one required property is `type`, which can be `default`, `role`, or `postType`. At most one `default` rule is allowed. Although the parser accepts an empty file or object as no rules, use a functional default rule for a usable editor configuration.
 
 Rules not of type `default` require an additional field. These are broken down below, along with examples of their possible values:
 
@@ -78,18 +79,18 @@ Rules not of type `default` require an additional field. These are broken down b
 | `role`     | `roles`        | name/slug of any [default][wp-default-roles] or [custom][wp-custom-roles] roles                |
 | `postType` | `postTypes`    | name/slug of any [default][wp-default-post-types] or [custom][wp-custom-post-types] post types |
 
-Each rule can have any one of the following properties.
+Each rule can have any of the following properties.
 
-- `allowedFeatures`: This is an array of the features that are allowed in the block editor. This list will expand with time, but we currently support two values: `codeEditor` (viewing the content of your post as code in the editor) and `lockBlocks`(ability to lock/unlock blocks that will restrict movement/deletion). If you do not want to enable these features, omit them from the array.
+- `allowedFeatures`: This is an array of the features that are allowed in the block editor. This list will expand with time, but we currently support two values: `codeEditor` (viewing the content of your post as code in the editor) and `lockBlocks` (ability to lock/unlock blocks that restrict movement/deletion). Use an empty array or omit the property when no optional features should be enabled by that rule.
 - `blockSettings`: These are specific settings related to the styling available for a block. They match the settings available in theme.json under the key `blocks`. The definition for that can be [found here][gutenberg-block-settings]. Unlike theme.json, you can nest these rules under a block name to apply different settings depending on the parent of a particular block.
-- `allowedBlocks`: These are the blocks allowed to be inserted into the block editor. Additionally, you can use `allowedBlocks` in `blockSettings` rules to restrict what blocks can be nested under a parent.
+- `allowedBlocks`: These are the blocks allowed to be inserted into the block editor. You can also put `allowedBlocks` in an exact parent's `blockSettings`. In the default cascading mode this adds child candidates to the root list; use restrictive hierarchy mode when the parent list must be exclusive.
 
-Non-default rule types will be merged with the default rule. This is done intentionally to avoid needless repetition of your default properties. If multiple non-default rule types are provided, they will be applied in the following ascending priority:
+Non-default rule types are combined with the default rule to avoid needless repetition. Matching non-default rules have the following ascending priority:
 
 1. Post Type
 2. Role
 
-So if a matching `postType` and `role` rule is found, the `role` rule will be applied, and the `postType` rule will be ignored. The best analogy is the CSS cascade where more specific rules overwrite less specific rules. We are making a choice that Role-based rules should overwrite Post Type rules. We will introduce a filter in the near future to allow this priority to be customized.
+Only the first matching rule of each type in file order is used. A matching role rule replaces each field it defines from the matching post-type rule; fields omitted from the role rule retain the post-type value. The default rule is then additive: its `allowedBlocks` and `allowedFeatures` are appended, and its `blockSettings` are recursively merged. If a user has multiple roles, order role rules carefully because the first intersecting role rule wins.
 
 #### Wildcards
 
@@ -156,7 +157,7 @@ Instead, only apply block settings to wildcards, and specify `allowedBlocks` to 
 
 ### Quick Start
 
-By default, the plugin uses [this][repo-governance-file-location] `governance-rules.json`. To start using the plugin with your own rules, you'll need to create your own `governance-rules.json` in [your private folder][wpvip-private-dir]. We recommend duplicating one of the starter rule sets provided [below](#starter-rule-sets), and adapting it for your needs. In order to take advantage of the rules schema for in-editor support, use `https://api.wpvip.com/schemas/plugins/governance.json`.
+By default, the plugin uses [this][repo-governance-file-location] `governance-rules.json`. To start using the plugin with your own rules, create `governance-rules.json` in [your private folder][wpvip-private-dir]. We recommend duplicating one of the starter rule sets provided [below](#starter-rule-sets) and adapting it for your needs. For in-editor schema support, use `https://api.wpvip.com/schemas/plugins/governance.json`.
 
 With this default rule set, all blocks and all features are enabled. It is sensible to set your default rule to the settings you want for your least privileged user then add capabilities with role and/or post type-specific rules.
 
@@ -479,7 +480,7 @@ With this rule set, the following rules will apply:
 
 - Default: Rules that apply to everyone as a baseline:
     - All core blocks are allowed
-    - Within a quote block, only heading and paragraph is allowed
+    - In the default cascading mode, all core blocks remain eligible within a quote; heading and paragraph are also explicitly allowed there. Return `false` from [`vip_governance__is_block_allowed_in_hierarchy`](#vip_governance__is_block_allowed_in_hierarchy) to make the parent list restrictive.
     - For a heading at the root level, a custom yellow color will appear as a possible text color option.
     - For a heading or paragraph within the quote block, a custom green color will appear as a possible text color option.
     - Blocks can be locked/unlocked or moved.
@@ -764,22 +765,28 @@ add_filter( 'vip_governance__default_role_for_user_without_roles', function( $de
 There is an admin settings menu titled `VIP Block Governance` that's created with the use of this plugin. This page offers:
 
 - Turning on and off the plugin quickly, without re-deploying.
-- View all the rules at once, and also any errors if the schema is invalid.
+- View all the rules at once, including JSON or rule-logic parsing errors.
 - View combined rules as a specific user role and/or for a specific post type.
 
 ![Admin setting in action][settings-panel-example-gif]
 
 ## Endpoints
 
-### `vip-governance/v1/<role>/rules`
+### `vip-governance/v1/rules`
 
-This endpoint is used to return the combined rules for a given role. This API is utilized by the settings page to visualize merged default and role rules for a selected role. It's only available to users with the `manage_options` permission.
+This endpoint returns effective rules for an optional role and/or post type. The settings page uses it to preview merged rules. It is available only to users with the `manage_options` capability.
+
+Pass `role` and `postType` as query parameters. Each is optional, and supplied values must name a registered WordPress role or post type. If `role` is omitted, resolution uses the authenticated user's roles:
+
+```text
+GET /wp-json/vip-governance/v1/rules?role=editor&postType=post
+```
 
 It has only three root level keys: `allowedBlocks`, `blockSettings`, and `allowedFeatures`.
 
 #### Example
 
-This example involves making a call to `http://my.site/wp-json/vip-governance/v1/editor/rules` for an `editor` role, while using [this](#default-and-user-role-rule-set) rule file found in the starter rule sets:
+This example is the response to `http://my.site/wp-json/vip-governance/v1/rules?role=editor` while using [the role starter rule set](#default-and-user-role-rule-set):
 
 ```json
 {
@@ -808,48 +815,51 @@ This example involves making a call to `http://my.site/wp-json/vip-governance/v1
 
 The plugin records two data points for analytics, on VIP sites:
 
-1. A usage metric when the block editor is loaded with the WordPress VIP Block Governance plugin activated. This analytic data simply is a counter, and includes no information about the post's content or metadata. It will only include the customer site ID to associate the usage.
+1. A usage metric sampled on roughly 10% of governance configuration loads. It is a counter associated with the customer site ID and includes no post content or metadata.
 
 2. When an error occurs from within the plugin on the [WordPress VIP][wpvip] platform. This is used to identify issues with customers for private follow-up.
 
-Both of these data points are a counter that is incremented and do not contain any other telemetry or sensitive data. You can see what's being [collected in code here][repo-analytics].
+Both data points are counters and do not contain other telemetry or sensitive data. If usage and error events are queued in the same request, only the error is sent. You can see what's being [collected in code here][repo-analytics].
 
 ## Development
 
-In order to ensure no dev dependencies are installed, the following can be done while installing the packages:
+Install development dependencies with:
 
+```bash
+npm ci
+composer install
 ```
-composer install --no-dev
-```
+
+The npm `postinstall` script installs production Composer dependencies, and the explicit `composer install` adds PHPUnit and PHPCS. Production installations can omit those development tools with `composer install --no-dev`.
 
 ### Tests
 
-We currently have unit, and e2e tests to ensure thorough code coverage of the plugin. These tests can be run locally with [`wp-env`][wp-env] and Docker.
+The PHP, JavaScript, and end-to-end tests can be run locally with [`wp-env`][wp-env] and Docker.
 
 For the PHP unit tests:
 
 ```
-wp-env start
-composer install
+npx wp-env start
 composer run test
 ```
 
 For the JS unit tests:
 
 ```
-npm install
 npm run test:js
 ```
 
 For the e2e tests:
 
 ```
-wp-env start
-composer install
-npm install
+npx wp-env start
 npx playwright install chromium --with-deps
-npx playwright test
+npm run test:e2e
 ```
+
+Run multisite PHP coverage with `composer run test-multisite`. The main wp-env site is at `http://localhost:8888`; Playwright targets the tests site at `http://localhost:8889`, using `admin` / `password` by default.
+
+Run both PHP and JavaScript unit tests with `npm test` after wp-env is running.
 
 <!-- Links -->
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,20 @@
 # Release steps
 
-# Release steps
-
 ## 1. Bump plugin version
 
-1. When the version is ready for release, bump the version number in `vip-governance.php` and `package.json`. Change plugin header and `WPCOMVIP__GOVERNANCE__PLUGIN_VERSION` to match new version.
-2. PR version changes (e.g. "Release 1.2.3") and merge to `trunk`. When a version change is detected, the `release` workflow will generate a new tag and release ZIP.
+1. From a clean `trunk` checkout, run `npm run release -- patch`, replacing `patch` with `minor` or `major` as needed. The command:
+   - creates `release/<version>`;
+   - updates `package.json`, `package-lock.json`, the plugin header, and `WPCOMVIP__GOVERNANCE__PLUGIN_VERSION`;
+   - stages only those version files; and
+   - commits them as `<version>`.
+2. Run `npm ci`, `composer install`, `npm run build`, and the relevant checks. Commit any intentional changes to the tracked `build/` and production `vendor/` files; the release ZIP is made from tracked files and the release workflow does not rebuild the bundle.
+3. Push the release branch manually and submit the PR. When the plugin header version change reaches `trunk`, the release workflow verifies it against `WPCOMVIP__GOVERNANCE__PLUGIN_VERSION`, creates the version tag and ZIP, and publishes a GitHub release.
+
+Preview a release without changing files or invoking Git:
+
+```bash
+npm run release -- patch --dry-run
+```
 
 ## 2. Update integrations
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,11 +10,13 @@
 2. Run `npm ci`, `composer install`, `npm run build`, and the relevant checks. Commit any intentional changes to the tracked `build/` and production `vendor/` files; the release ZIP is made from tracked files and the release workflow does not rebuild the bundle.
 3. Push the release branch manually and submit the PR. When the plugin header version change reaches `trunk`, the release workflow verifies it against `WPCOMVIP__GOVERNANCE__PLUGIN_VERSION`, creates the version tag and ZIP, and publishes a GitHub release.
 
-Preview a release without changing files or invoking Git:
+Test the version updates without invoking Git:
 
 ```bash
 npm run release -- patch --dry-run
 ```
+
+This changes the version files so they can be inspected; restore them before running a real release.
 
 ## 2. Update integrations
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,14 +10,6 @@
 2. Run `npm ci`, `composer install`, `npm run build`, and the relevant checks. Commit any intentional changes to the tracked `build/` and production `vendor/` files; the release ZIP is made from tracked files and the release workflow does not rebuild the bundle.
 3. Push the release branch manually and submit the PR. When the plugin header version change reaches `trunk`, the release workflow verifies it against `WPCOMVIP__GOVERNANCE__PLUGIN_VERSION`, creates the version tag and ZIP, and publishes a GitHub release.
 
-Test the version updates without invoking Git:
-
-```bash
-npm run release -- patch --dry-run
-```
-
-This changes the version files so they can be inspected; restore them before running a real release.
-
 ## 2. Update integrations
 
 Patch updates (e.g. `1.2.3` -> `1.2.4`) do not require any additional steps.

--- a/bin/release
+++ b/bin/release
@@ -2,13 +2,12 @@
 
 set -eu
 
-if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
-	echo "Usage: npm run release -- <major|minor|patch> [--dry-run]"
+if [ "$#" -ne 1 ]; then
+	echo "Usage: npm run release -- <major|minor|patch>"
 	exit 1
 fi
 
 release_type=$1
-mode=${2:-}
 php_file="vip-governance.php"
 package_file="package.json"
 package_lock_file="package-lock.json"
@@ -41,27 +40,12 @@ esac
 
 branch_name="release/$new_version"
 
-case $mode in
-	--dry-run)
-		use_git=false
-		;;
-	'')
-		use_git=true
-		;;
-	*)
-		echo "Unknown option: $mode"
-		exit 1
-		;;
-esac
-
-if [ "$use_git" = true ]; then
-	if [ -n "$(git status --porcelain)" ]; then
-		echo "The working tree must be clean before creating a release."
-		exit 1
-	fi
-
-	git checkout -b "$branch_name"
+if [ -n "$(git status --porcelain)" ]; then
+	echo "The working tree must be clean before creating a release."
+	exit 1
 fi
+
+git checkout -b "$branch_name"
 
 sed -i.bak "s/Version: $current_version/Version: $new_version/" "$php_file"
 sed -i.bak "s/WPCOMVIP__GOVERNANCE__PLUGIN_VERSION', '$current_version'/WPCOMVIP__GOVERNANCE__PLUGIN_VERSION', '$new_version'/" "$php_file"
@@ -72,11 +56,7 @@ sed -i.bak "s/\"version\": \"$current_package_version\"/\"version\": \"$new_vers
 rm "$package_file.bak"
 npm install --package-lock-only --ignore-scripts
 
-if [ "$use_git" = true ]; then
-	git add "$php_file" "$package_file" "$package_lock_file"
-	git commit -m "$new_version"
+git add "$php_file" "$package_file" "$package_lock_file"
+git commit -m "$new_version"
 
-	echo "Created $branch_name. Push it manually when ready."
-else
-	echo "Updated files to $new_version without running Git commands."
-fi
+echo "Created $branch_name. Push it manually when ready."

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+	echo "Usage: npm run release -- <major|minor|patch> [--dry-run]"
+	exit 1
+fi
+
+release_type=$1
+dry_run=${2:-}
+php_file="vip-governance.php"
+package_file="package.json"
+package_lock_file="package-lock.json"
+current_version=$(sed -n 's/.*Version: \([0-9.]*\).*/\1/p' "$php_file")
+
+old_ifs=$IFS
+IFS=.
+set -- $current_version
+IFS=$old_ifs
+
+major=$1
+minor=$2
+patch=$3
+
+case $release_type in
+	major)
+		new_version="$((major + 1)).0.0"
+		;;
+	minor)
+		new_version="$major.$((minor + 1)).0"
+		;;
+	patch)
+		new_version="$major.$minor.$((patch + 1))"
+		;;
+	*)
+		echo "Invalid release type. Use major, minor, or patch."
+		exit 1
+		;;
+esac
+
+branch_name="release/$new_version"
+
+if [ "$dry_run" = "--dry-run" ]; then
+	echo "Would release $current_version as $new_version"
+	echo "Branch: $branch_name"
+	echo "Commit: $new_version"
+	exit 0
+fi
+
+if [ -n "$dry_run" ]; then
+	echo "Unknown option: $dry_run"
+	exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+	echo "The working tree must be clean before creating a release."
+	exit 1
+fi
+
+git checkout -b "$branch_name"
+sed -i.bak "s/Version: $current_version/Version: $new_version/" "$php_file"
+sed -i.bak "s/WPCOMVIP__GOVERNANCE__PLUGIN_VERSION', '$current_version'/WPCOMVIP__GOVERNANCE__PLUGIN_VERSION', '$new_version'/" "$php_file"
+rm "$php_file.bak"
+
+current_package_version=$(node -p "require('./package.json').version")
+sed -i.bak "s/\"version\": \"$current_package_version\"/\"version\": \"$new_version\"/" "$package_file"
+rm "$package_file.bak"
+npm install --package-lock-only --ignore-scripts
+
+git add "$php_file" "$package_file" "$package_lock_file"
+git commit -m "$new_version"
+
+echo "Created $branch_name. Push it manually when ready."

--- a/bin/release
+++ b/bin/release
@@ -8,7 +8,7 @@ if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
 fi
 
 release_type=$1
-dry_run=${2:-}
+mode=${2:-}
 php_file="vip-governance.php"
 package_file="package.json"
 package_lock_file="package-lock.json"
@@ -41,24 +41,28 @@ esac
 
 branch_name="release/$new_version"
 
-if [ "$dry_run" = "--dry-run" ]; then
-	echo "Would release $current_version as $new_version"
-	echo "Branch: $branch_name"
-	echo "Commit: $new_version"
-	exit 0
+case $mode in
+	--dry-run)
+		use_git=false
+		;;
+	'')
+		use_git=true
+		;;
+	*)
+		echo "Unknown option: $mode"
+		exit 1
+		;;
+esac
+
+if [ "$use_git" = true ]; then
+	if [ -n "$(git status --porcelain)" ]; then
+		echo "The working tree must be clean before creating a release."
+		exit 1
+	fi
+
+	git checkout -b "$branch_name"
 fi
 
-if [ -n "$dry_run" ]; then
-	echo "Unknown option: $dry_run"
-	exit 1
-fi
-
-if [ -n "$(git status --porcelain)" ]; then
-	echo "The working tree must be clean before creating a release."
-	exit 1
-fi
-
-git checkout -b "$branch_name"
 sed -i.bak "s/Version: $current_version/Version: $new_version/" "$php_file"
 sed -i.bak "s/WPCOMVIP__GOVERNANCE__PLUGIN_VERSION', '$current_version'/WPCOMVIP__GOVERNANCE__PLUGIN_VERSION', '$new_version'/" "$php_file"
 rm "$php_file.bak"
@@ -68,7 +72,11 @@ sed -i.bak "s/\"version\": \"$current_package_version\"/\"version\": \"$new_vers
 rm "$package_file.bak"
 npm install --package-lock-only --ignore-scripts
 
-git add "$php_file" "$package_file" "$package_lock_file"
-git commit -m "$new_version"
+if [ "$use_git" = true ]; then
+	git add "$php_file" "$package_file" "$package_lock_file"
+	git commit -m "$new_version"
 
-echo "Created $branch_name. Push it manually when ready."
+	echo "Created $branch_name. Push it manually when ready."
+else
+	echo "Updated files to $new_version without running Git commands."
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vip-governance",
-	"version": "1.0.15",
+	"version": "1.0.16",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vip-governance",
-			"version": "1.0.15",
+			"version": "1.0.16",
 			"hasInstallScript": true,
 			"devDependencies": {
 				"@automattic/eslint-plugin-wpvip": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vip-governance",
-	"version": "1.0.15",
+	"version": "1.0.16",
 	"description": "This is a plugin adding additional governance capabilities to the block editor.",
 	"private": true,
 	"author": "WPVIP",
@@ -48,9 +48,11 @@
 		"packages-update": "wp-scripts packages-update",
 		"prepare": "npx simple-git-hooks",
 		"postinstall": "composer install --no-dev",
+		"release": "./bin/release",
 		"test": "npm run test:unit",
 		"test:unit": "npm run test:php && npm run test:js",
 		"test:e2e": "npx playwright test",
+		"test:php": "composer run test",
 		"test:js": "wp-scripts test-unit-js",
 		"wp-cli": "wp-env run cli -- wp"
 	},


### PR DESCRIPTION
## Description

This PR refreshes the repository documentation and adds a streamlined local release workflow.

Release quality-of-life improvements include:

- Adding `npm run release -- major|minor|patch`.
- Creating release branches named `release/<version>`.
- Updating the plugin header, `WPCOMVIP__GOVERNANCE__PLUGIN_VERSION`, `package.json`, and `package-lock.json`.
- Committing version changes using the version number as the commit message.
- Leaving the release branch unpushed for manual review.
- Refreshing only the npm lockfile without running lifecycle scripts, preventing unrelated Composer-generated changes.
- Documenting the updated release process in `RELEASE.md`.

The package metadata is synchronized with plugin version `1.0.16`, and the missing `test:php` npm command has been added so the combined unit-test command works correctly.

This PR does not change the plugin’s runtime governance behaviour.

## Steps to Test

1. Check out the PR.
2. Install the development dependencies:

   ```bash
   npm ci
   composer install
   ```

3. Verify the release script syntax:

   ```bash
   sh -n bin/release
   ```